### PR TITLE
Refactor/flat folders structure

### DIFF
--- a/src/commands/developer/eval.ts
+++ b/src/commands/developer/eval.ts
@@ -3,7 +3,7 @@
 
 import { Colors, CommandInteraction } from 'discord.js';
 import { inspect } from 'util';
-import { CommandBuilder } from './../../modules/bot/handlers';
+import { CommandBuilder } from '../../handlers';
 
 export const data = new CommandBuilder()
   .setName('eval')

--- a/src/commands/utility/help.ts
+++ b/src/commands/utility/help.ts
@@ -7,7 +7,7 @@ import {
   StringSelectMenuInteraction,
 } from 'discord.js';
 import { PyeClient, client } from '../..';
-import { CommandBuilder } from '../../modules/bot/handlers';
+import { CommandBuilder } from '../../handlers';
 import { toCapitalize } from '../../utils/text';
 
 export const data = new CommandBuilder()

--- a/src/commands/utility/ping.ts
+++ b/src/commands/utility/ping.ts
@@ -1,6 +1,6 @@
 import { Colors, CommandInteraction, EmbedBuilder } from 'discord.js';
 import { PyeClient } from '../..';
-import { CommandBuilder } from '../../modules/bot/handlers';
+import { CommandBuilder } from '../../handlers';
 
 export const data = new CommandBuilder()
   .setName('ping')

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,7 +1,7 @@
 import { Colors, Events, Interaction } from 'discord.js';
 import { PyeClient, client } from '..';
-import { checkCommandPermissions } from '../modules/bot/handlers';
-import { reportMessageError } from '../modules/helpers/reporting';
+import { checkCommandPermissions } from '../handlers';
+import { reportMessageError } from '../helpers/reporting';
 
 export default {
   name: Events.InteractionCreate,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,6 +1,6 @@
 import { Events, Message } from 'discord.js';
 import { PyeClient, client } from '..';
-import { nsfwFilter } from '../modules/bot/functions/nsfwFilter';
+import { nsfwFilter } from '../functions/nsfwFilter';
 
 export default {
   name: Events.MessageCreate,

--- a/src/events/threadCreate.ts
+++ b/src/events/threadCreate.ts
@@ -1,8 +1,8 @@
 import { Events, ThreadChannel } from "discord.js";
 import { PyeClient } from "..";
-import { shareThreads } from "../modules/bot/functions/shareThread";
-import { cohereAIHandler } from "../modules/bot/functions/threadsAi";
-import { reportEventError } from "../modules/helpers/reporting";
+import { shareThreads } from "../functions/shareThread";
+import { cohereAIHandler } from "../functions/threadsAi";
+import { reportEventError } from "../helpers/reporting";
 
 export default {
   name: Events.ThreadCreate,

--- a/src/functions/nsfwFilter.ts
+++ b/src/functions/nsfwFilter.ts
@@ -1,8 +1,8 @@
 import { HfInference } from '@huggingface/inference';
 import { Message } from 'discord.js';
-import { PyeClient } from '../../..';
-import config from '../../../config';
-import { sendNSFWReport } from '../../helpers/reporting';
+import { PyeClient } from '..';
+import config from '../config';
+import { sendNSFWReport } from '../helpers/reporting';
 
 const { HF_SECRET } = process.env;
 

--- a/src/functions/shareThread.ts
+++ b/src/functions/shareThread.ts
@@ -1,7 +1,7 @@
 import { ChannelType, Colors, EmbedBuilder, ThreadChannel } from 'discord.js';
-import { PyeClient } from '../../..';
-import config from '../../../config';
-import { toCapitalize } from '../../../utils/text';
+import { PyeClient } from '..';
+import config from '../config';
+import { toCapitalize } from '../utils/text';
 
 export const shareThreads = async (pyeClient: PyeClient,thread: ThreadChannel) => {
   if (typeof thread.parentId !== 'string') return;

--- a/src/functions/threadsAi.ts
+++ b/src/functions/threadsAi.ts
@@ -1,7 +1,7 @@
 import cohere from 'cohere-ai';
 import { ChannelType, ThreadChannel } from 'discord.js';
 import { translate } from 'google-translate-api-x';
-import config from '../../../config';
+import config from '../config';
 
 export const cohereAIHandler = async (thread: ThreadChannel) => {
   if (typeof thread.parentId !== 'string') return;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -14,8 +14,8 @@ import {
 } from 'discord.js';
 import { lstatSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { PyeClient, client } from '../..';
-import config from '../../config';
+import { PyeClient, client } from '.';
+import config from './config';
 
 interface slashCommandData
   extends RESTPostAPIChatInputApplicationCommandsJSONBody {

--- a/src/helpers/reporting.ts
+++ b/src/helpers/reporting.ts
@@ -7,8 +7,8 @@ import {
   MessageCreateOptions,
   MessagePayload,
 } from "discord.js";
-import { PyeClient } from "../..";
-import config from "../../config";
+import { PyeClient } from "..";
+import config from "../config";
 
 type ReportError = {
   client: PyeClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import {
   loadEvents,
   loadSlashCommands,
   registerSlashCommands,
-} from './modules/bot/handlers';
-import { reportError } from './modules/helpers/reporting';
+} from './handlers';
+import { reportError } from './helpers/reporting';
 
 export const client = {
   config,


### PR DESCRIPTION
We dont need alias library because the structure is not that big or unclear ( yet ), we can think about that in the future when we implement some new things, i.e db/storage

* modules/bot was not clear to me, i just change folders/files to /src level
* now imports are not more than 3 levels ( we actually use autoimport anyway so levels shouldnt be a real problem)
* Alias path require mor effort to do reviews because we have to check that people use it correctly

![image](https://github.com/pye-community/pye-community-bot/assets/67301108/e59d2b3c-b5a6-4763-95c5-52965e3691c0)

 